### PR TITLE
Feat: hyyro bit vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ levenjs <br>
 [![Tests](https://github.com/mammothb/levenjs/actions/workflows/tests.yml/badge.svg)](https://github.com/mammothb/levenjs/actions/workflows/tests.yml)
 =============
 
-Fast implementation of the Levenshtein edit distance. The original C# project 
-can be found at [SoftWx.Match](https://github.com/softwx/SoftWx.Match).
+Fast implementation of the Levenshtein edit distance. References for the various
+function can be found in the docstrings [[1](https://github.com/softwx/SoftWx.Match),
+[2](https://github.com/maxbachmann/rapidfuzz-cpp),
+[3](https://github.com/ka-weihe/fastest-levenshtein)].
 
 ## Install
 ```
@@ -21,38 +23,46 @@ If you want to limit the maximum edit distance returned.
 ```js
 import levenjs from "levenjs";
 
-levenjs("distance", "dist", /*maxDistance=*/ 2);  // 2
+levenjs("distance", "dist", /*maxDist=*/ 2);  // 2
 ```
 
 ## Benchmark
-Benchmarked against [`ukkonen`](https://github.com/sunesimonsen/ukkonen) and the
-fastest implementation of Levenshtein edit distance on NPM
-[`leven`](https://github.com/sindresorhus/leven).
+Benchmarked against [`leven`](https://github.com/sindresorhus/leven) and
+[`fastest-levenshtein`](https://github.com/ka-weihe/fastest-levenshtein).
 ```
 One word
-         ukkonen x 429,453 ops/sec ±0.25% (97 runs sampled)
-         leven x 660,136 ops/sec ±0.18% (97 runs sampled)
-         levenjs x 617,170 ops/sec ±0.16% (99 runs sampled)
-Sentence, small difference
-         ukkonen x 1,218,868 ops/sec ±0.21% (98 runs sampled)
-         leven x 212,308 ops/sec ±0.19% (98 runs sampled)
-         levenjs x 214,374 ops/sec ±0.75% (95 runs sampled)
+         leven               x 646,822 ops/sec ±0.64% (98 runs sampled)
+         fastest-levenshtein x 1,529,761 ops/sec ±0.76% (95 runs sampled)
+         levenjs             x 1,331,218 ops/sec ±0.34% (97 runs sampled)
+Short sentence, small difference
+         leven               x 868,577 ops/sec ±0.63% (90 runs sampled)
+         fastest-levenshtein x 6,881,822 ops/sec ±0.48% (97 runs sampled)
+         levenjs             x 5,578,840 ops/sec ±0.98% (93 runs sampled)
+Short sentence, similar prefix and suffix, small difference
+         leven               x 2,242,494 ops/sec ±0.63% (92 runs sampled)
+         fastest-levenshtein x 4,920,882 ops/sec ±0.39% (98 runs sampled)
+         levenjs             x 6,336,442 ops/sec ±0.57% (92 runs sampled)
 Long text, small difference
-         ukkonen x 154,164 ops/sec ±0.25% (95 runs sampled)
-         leven x 1,034 ops/sec ±0.16% (98 runs sampled)
-         levenjs x 1,028 ops/sec ±0.46% (97 runs sampled)
+         leven               x 1,011 ops/sec ±0.67% (95 runs sampled)
+         fastest-levenshtein x 10,350 ops/sec ±0.47% (97 runs sampled)
+         levenjs             x 10,796 ops/sec ±0.42% (97 runs sampled)
+Long text, small difference, threshold 3
+         leven               x 894 ops/sec ±0.41% (97 runs sampled)
+         fastest-levenshtein x 10,374 ops/sec ±1.31% (96 runs sampled)
+         levenjs             x 397,756 ops/sec ±0.52% (97 runs sampled)
+Long text, small difference, threshold 20
+         leven               x 1,030 ops/sec ±0.43% (97 runs sampled)
+         fastest-levenshtein x 10,312 ops/sec ±0.55% (97 runs sampled)
+         levenjs             x 17,998 ops/sec ±0.41% (94 runs sampled)
 Long text, many difference
-         ukkonen x 576 ops/sec ±0.16% (94 runs sampled)
-         leven x 630 ops/sec ±0.11% (97 runs sampled)
-         levenjs x 641 ops/sec ±0.20% (96 runs sampled)
-Long text, small difference, threshold 10
-         ukkonen x 194,398 ops/sec ±0.38% (97 runs sampled)
-         leven x 1,035 ops/sec ±0.23% (97 runs sampled)
-         levenjs x 18,689 ops/sec ±0.24% (100 runs sampled)
+         leven               x 622 ops/sec ±0.58% (96 runs sampled)
+         fastest-levenshtein x 7,422 ops/sec ±0.43% (98 runs sampled)
+         levenjs             x 6,342 ops/sec ±0.28% (99 runs sampled)
 Long text, many difference, threshold 40
-         ukkonen x 123,123 ops/sec ±0.18% (99 runs sampled)
-         leven x 635 ops/sec ±0.12% (95 runs sampled)
-         levenjs x 191,112 ops/sec ±0.15% (96 runs sampled)
+         leven               x 634 ops/sec ±0.25% (95 runs sampled)
+         fastest-levenshtein x 7,879 ops/sec ±0.26% (99 runs sampled)
+         levenjs             x 169,151 ops/sec ±0.50% (95 runs sampled)
 ```
-Other than single word cases, mostly comparable performance with `leven`,
-better performance when `maxDistance` is set.
+Slightly poorer performance than `fastest-levenshtein` in uncapped cases but
+better performance when pre-/post- fix trimming shortens string lengths past
+certain break points. Also better performance when a `maxDist` threshold is set.

--- a/bench.js
+++ b/bench.js
@@ -3,7 +3,7 @@
 import Benchmark from "benchmark";
 import levenjs from "./index.js";
 import leven from "leven";
-import ukkonen from "ukkonen";
+import { distance } from "fastest-levenshtein";
 
 const oneWord = (fn) => {
   fn("a", "b");
@@ -22,10 +22,14 @@ const oneWord = (fn) => {
   fn("因為我是中國人所以我會說中文", "因為我是英國人所以我會說英文");
 };
 
-const sentenceSmallDiff = (fn) => {
+const shortTextSmallDiff = (fn) => {
+  fn("Lore Isum is dummy txt!", "Eorem Ifpsum is dummy text.");
+};
+
+const shortTextSimilarSmallDiff = (fn) => {
   fn(
-    "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
-    "Lorem Ipsum is simply clever text of the printing and typesetting industries."
+    "Lorem Ipsu is imply ummy text.",
+    "Lorem Ipsurm ies simplyc dbuammy text."
   );
 };
 
@@ -36,14 +40,15 @@ const longTextSmallDiff = (fn) => {
   );
 };
 
-const longTextManyDiff = (fn) => {
+const longTextMax3 = (fn) => {
   fn(
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, eu placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Etiam lacinia pretium luctus. Mauris nulla turpis, suscipit vitae lobortis quis, tempor sed ex. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis vitae ipsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, eu condimentum turpis scelerisque quis.",
-    "Curabitur fringilla eros lacus, et placerat magna pretium in. Suspendisse ut egestas dui. Nam quis sapien eget enim interdum interdum. Phasellus metus ligula, lacinia at tellus eu, iaculis blandit libero. Proin risus sem, ornare a orci et, aliquam rutrum elit. Aenean ac posuere justo, a maximus orci. In molestie nibh quis libero elementum, vel pellentesque metus volutpat. Maecenas non quam felis. Proin congue aliquet mauris laoreet viverra. Fusce auctor sapien a neque varius pellentesque. Nam ut sem neque. Pellentesque bibendum aliquet consectetur. Nam finibus diam non vestibulum maximus. Integer aliquet mattis elit, vitae vehicula erat pulvinar at. Ut placerat viverra aliquam. Nulla vehicula hendrerit justo."
+    "Lorem Ipsum dolor sit amet, cnsectetur elite adipiscing. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Etiam lacinia pretium luctus. Mauris nulla turpis, suscipit vitae lobortis quis, tempor sed ex. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis Vitae jpsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, deu condimentum turpis scelerisque quis.",
+    "Lorem Ipsum dolor sit amet, consectetur elit adipiscing. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Etiam lacinia pretium luctus. Mauris nulla turpis, suscipit vitae lobortis quis, tempor sed ex. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis Vitae ipsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, eu condimentum turpis scelerisque quis.",
+    3
   );
 };
 
-const longTextMaxDistance = (fn) => {
+const longTextMax20 = (fn) => {
   fn(
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, eu placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Etiam lacinia pretium luctus. Mauris nulla turpis, suscipit vitae lobortis quis, tempor sed ex. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis vitae ipsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, eu condimentum turpis scelerisque quis.",
     "Lorem Ipsum dolor sit amet, consectetur elit adipiscing. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Etiam lacinia pretium luctus. Mauris nulla turpis, suscipit vitae lobortis quis, tempor sed ex. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis Vitae ipsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, eu condimentum turpis scelerisque quis.",
@@ -51,7 +56,14 @@ const longTextMaxDistance = (fn) => {
   );
 };
 
-const longTextManyDiffMaxDistance = (fn) => {
+const longTextManyDiff = (fn) => {
+  fn(
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, eu placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Etiam lacinia pretium luctus. Mauris nulla turpis, suscipit vitae lobortis quis, tempor sed ex. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis vitae ipsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, eu condimentum turpis scelerisque quis.",
+    "Curabitur fringilla eros lacus, et placerat magna pretium in. Suspendisse ut egestas dui. Nam quis sapien eget enim interdum interdum. Phasellus metus ligula, lacinia at tellus eu, iaculis blandit libero. Proin risus sem, ornare a orci et, aliquam rutrum elit. Aenean ac posuere justo, a maximus orci. In molestie nibh quis libero elementum, vel pellentesque metus volutpat. Maecenas non quam felis. Proin congue aliquet mauris laoreet viverra. Fusce auctor sapien a neque varius pellentesque. Nam ut sem neque. Pellentesque bibendum aliquet consectetur. Nam finibus diam non vestibulum maximus. Integer aliquet mattis elit, vitae vehicula erat pulvinar at. Ut placerat viverra aliquam. Nulla vehicula hendrerit justo."
+  );
+};
+
+const longTextManyDiff40 = (fn) => {
   fn(
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tellus sapien, rhoncus sed bibendum in, facilisis non urna. Cras non mattis tellus, nec facilisis nisi. Proin vel purus eros. Morbi ultrices egestas mi vitae laoreet. Ut feugiat est lorem, a rhoncus mi lacinia vel. Aenean et velit neque. Quisque accumsan mi ligula, eu placerat lorem elementum ac. Nunc congue, eros eu aliquam commodo, leo orci tristique nulla, eu tempus quam justo eu neque. Nulla purus elit, porttitor ut sollicitudin sed, dictum vel justo. Mauris orci nisi, lacinia dictum augue nec, condimentum suscipit metus. Sed elementum enim eget venenatis mollis. Etiam sed congue neque, id tristique ex. Duis vitae ipsum nec ligula vulputate ullamcorper. Phasellus fringilla odio turpis, eu condimentum turpis scelerisque quis.",
     "Curabitur fringilla eros lacus, et placerat magna pretium in. Suspendisse ut egestas dui. Nam quis sapien eget enim interdum interdum. Phasellus metus ligula, lacinia at tellus eu, iaculis blandit libero. Proin risus sem, ornare a orci et, aliquam rutrum elit. Aenean ac posuere justo, a maximus orci. In molestie nibh quis libero elementum, vel pellentesque metus volutpat. Maecenas non quam felis. Proin congue aliquet mauris laoreet viverra. Fusce auctor sapien a neque varius pellentesque. Nam ut sem neque. Pellentesque bibendum aliquet consectetur. Nam finibus diam non vestibulum maximus. Integer aliquet mattis elit, vitae vehicula erat pulvinar at. Ut placerat viverra aliquam. Nulla vehicula hendrerit justo. Contrary to popular belief, Lorem Ipsum is not simply random text.",
@@ -67,85 +79,117 @@ function onCycle(event) {
   console.log(`\t ${String(event.target)}`);
 }
 
+const fastestLevenshteinName = "fastest-levenshtein";
+const levenName = "leven".padEnd(fastestLevenshteinName.length, " ");
+const levenjsName = "levenjs".padEnd(fastestLevenshteinName.length, " ");
+
 Benchmark.Suite("One word")
-  .add("ukkonen", () => {
-    oneWord(ukkonen);
-  })
-  .add("leven", () => {
+  .add(levenName, () => {
     oneWord(leven);
   })
-  .add("levenjs", () => {
+  .add(fastestLevenshteinName, () => {
+    oneWord(distance);
+  })
+  .add(levenjsName, () => {
     oneWord(levenjs);
   })
   .on("start", onStart)
   .on("cycle", onCycle)
   .run();
 
-Benchmark.Suite("Sentence, small difference")
-  .add("ukkonen", () => {
-    sentenceSmallDiff(ukkonen);
+Benchmark.Suite("Short sentence, small difference")
+  .add(levenName, () => {
+    shortTextSmallDiff(leven);
   })
-  .add("leven", () => {
-    sentenceSmallDiff(leven);
+  .add(fastestLevenshteinName, () => {
+    shortTextSmallDiff(distance);
   })
-  .add("levenjs", () => {
-    sentenceSmallDiff(levenjs);
+  .add(levenjsName, () => {
+    shortTextSmallDiff(levenjs);
+  })
+  .on("start", onStart)
+  .on("cycle", onCycle)
+  .run();
+
+Benchmark.Suite("Short sentence, similar prefix and suffix, small difference")
+  .add(levenName, () => {
+    shortTextSimilarSmallDiff(leven);
+  })
+  .add(fastestLevenshteinName, () => {
+    shortTextSimilarSmallDiff(distance);
+  })
+  .add(levenjsName, () => {
+    shortTextSimilarSmallDiff(levenjs);
   })
   .on("start", onStart)
   .on("cycle", onCycle)
   .run();
 
 Benchmark.Suite("Long text, small difference")
-  .add("ukkonen", () => {
-    longTextSmallDiff(ukkonen);
-  })
-  .add("leven", () => {
+  .add(levenName, () => {
     longTextSmallDiff(leven);
   })
-  .add("levenjs", () => {
+  .add(fastestLevenshteinName, () => {
+    longTextSmallDiff(distance);
+  })
+  .add(levenjsName, () => {
     longTextSmallDiff(levenjs);
   })
   .on("start", onStart)
   .on("cycle", onCycle)
   .run();
 
-Benchmark.Suite("Long text, many difference")
-  .add("ukkonen", () => {
-    longTextManyDiff(ukkonen);
+Benchmark.Suite("Long text, small difference, threshold 3")
+  .add(levenName, () => {
+    longTextMax3(leven);
   })
-  .add("leven", () => {
+  .add(fastestLevenshteinName, () => {
+    longTextMax3(distance);
+  })
+  .add(levenjsName, () => {
+    longTextMax3(levenjs);
+  })
+  .on("start", onStart)
+  .on("cycle", onCycle)
+  .run();
+
+Benchmark.Suite("Long text, small difference, threshold 20")
+  .add(levenName, () => {
+    longTextMax20(leven);
+  })
+  .add(fastestLevenshteinName, () => {
+    longTextMax20(distance);
+  })
+  .add(levenjsName, () => {
+    longTextMax20(levenjs);
+  })
+  .on("start", onStart)
+  .on("cycle", onCycle)
+  .run();
+
+Benchmark.Suite("Long text, many difference")
+  .add(levenName, () => {
     longTextManyDiff(leven);
   })
-  .add("levenjs", () => {
+  .add(fastestLevenshteinName, () => {
+    longTextManyDiff(distance);
+  })
+  .add(levenjsName, () => {
     longTextManyDiff(levenjs);
   })
   .on("start", onStart)
   .on("cycle", onCycle)
   .run();
 
-Benchmark.Suite("Long text, small difference, threshold 10")
-  .add("ukkonen", () => {
-    longTextMaxDistance(ukkonen);
-  })
-  .add("leven", () => {
-    longTextMaxDistance(leven);
-  })
-  .add("levenjs", () => {
-    longTextMaxDistance(levenjs);
-  })
-  .on("start", onStart)
-  .on("cycle", onCycle)
-  .run();
-
 Benchmark.Suite("Long text, many difference, threshold 40")
-  .add("ukkonen", () => {
-    longTextManyDiffMaxDistance(ukkonen);
+  .add(levenName, () => {
+    longTextManyDiff40(leven);
   })
-  .add("leven", () => {
-    longTextManyDiffMaxDistance(leven);
+  .add(fastestLevenshteinName, () => {
+    longTextManyDiff40(distance);
   })
-  .add("levenjs", () => {
-    longTextManyDiffMaxDistance(levenjs);
+  .add(levenjsName, () => {
+    longTextManyDiff40(levenjs);
   })
   .on("start", onStart)
   .on("cycle", onCycle)

--- a/index.js
+++ b/index.js
@@ -1,36 +1,304 @@
+const pmVector = new Uint32Array(0x10000);
+const uint32Max = 0x100000000 - 1;
 const s2CharCodes = [];
 const char1Costs = [];
 
-const distance = (s1, s2, len1, len2, offset) => {
-  for (let i = 0; i < len2; ++i) {
-    char1Costs[i] = i + 1;
-    s2CharCodes[i] = s2.charCodeAt(offset + i);
-  }
+/**
+ * Matrix of all the possible edit sequences for each given maxDist and
+ * lenDiff.
+ *
+ * 01 = DELETE, 10 = INSERT, 11 = REPLACE
+ *
+ * @see {@link fujimoto2018} for more information.
+ */
+const opsMatrix = [
+  // maxDist=1
+  [0x03], // lenDiff=0
+  [0x01], // lenDiff=1
+  // maxDist=2
+  [0x0f, 0x09, 0x06], // lenDiff=0
+  [0x0d, 0x07], // lenDiff=1
+  [0x05], // lenDiff=2
+  // maxDist=3
+  [0x3f, 0x39, 0x36, 0x2d, 0x27, 0x1e, 0x1b], // lenDiff=0
+  [0x3d, 0x37, 0x25, 0x1f, 0x19, 0x16], // lenDiff=1
+  [0x35, 0x1d, 0x17], // lenDiff=2
+  [0x15], // lenDiff=3
+];
 
-  let currentCost = 0;
-  for (let i = 0; i < len1; ++i) {
-    let aboveCharCost = i;
-    let leftCharCost = i;
-    const char1 = s1.charCodeAt(offset + i);
-    for (let j = 0; j < len2; ++j) {
-      currentCost = leftCharCost;
-      leftCharCost = char1Costs[j];
-      if (char1 !== s2CharCodes[j]) {
-        if (aboveCharCost < currentCost) {
-          currentCost = aboveCharCost;
-        }
-        if (leftCharCost < currentCost) {
-          currentCost = leftCharCost;
-        }
-        ++currentCost;
+/**
+ * Implementation of mbleven by fujimoto2018, handles up to maxDist<4.
+ *
+ * Reference:
+ * RapidFuzz: https://github.com/maxbachmann/rapidfuzz-cpp
+ * mbleven: https://github.com/fujimotos/mbleven
+ *
+ * @param {string} s1 - The first, shorter, string.
+ * @param {string} s2 - The other string.
+ * @param {number} len1 - Length of `s1` less the common suffix.
+ * @param {number} len2 - Length of `s2` less the common suffix.
+ * @param {number} offset - Length of common prefix.
+ * @param {number} maxDist - Maximum edit distance allowed between the `s1`
+ *    and `s2`.
+ * @returns {number} The Levenshtein distance between `s1` and `s2.
+ */
+const fujimoto2018 = (s1, s2, len1, len2, offset, maxDist) => {
+  const lenDiff = len2 - len1;
+  const possibleOps =
+    opsMatrix[(maxDist + maxDist * maxDist) / 2 + lenDiff - 1];
+  let cost = maxDist + 1;
+  for (let i = 0; i < possibleOps.length; ++i) {
+    let ops = possibleOps[i];
+    let s1Pos = 0;
+    let s2Pos = 0;
+    let currCost = 0;
+    while (s1Pos < len1 && s2Pos < len2) {
+      if (s1.charCodeAt(s1Pos + offset) !== s2.charCodeAt(s2Pos + offset)) {
+        ++currCost;
+        if (!ops) break;
+        if (ops & 1) ++s1Pos;
+        if (ops & 2) ++s2Pos;
+        ops >>= 2;
+      } else {
+        ++s1Pos;
+        ++s2Pos;
       }
-      aboveCharCost = currentCost;
-      char1Costs[j] = currentCost;
     }
+    currCost += len1 - s1Pos + len2 - s2Pos;
+    cost = currCost < cost ? currCost : cost;
   }
-  return currentCost;
+  return cost > maxDist ? maxDist : cost;
 };
 
+/**
+ * Implementation of "A Bit-Vector Algorithm for Computing Levenshtein and
+ * Damerau Edit Distances" by Hyyro (2003), using computer word size = 32.
+ *
+ * Reference:
+ * RapidFuzz: https://github.com/maxbachmann/rapidfuzz-cpp
+ *
+ * @param {string} s1 - The first, shorter, string.
+ * @param {string} s2 - The other string.
+ * @param {number} len1 - Length of `s1` less the common suffix.
+ * @param {number} len2 - Length of `s2` less the common suffix.
+ * @param {number} offset - Length of common prefix.
+ * @param {number} maxDist - Maximum edit distance allowed between the `s1`
+ *    and `s2`.
+ * @returns {number} The Levenshtein distance between `s1` and `s2.
+ */
+const hyyro2003 = (s1, s2, len1, len2, offset, maxDist) => {
+  // Set up pattern match vector
+  let i = len1;
+  while (i--) {
+    pmVector[s1.charCodeAt(offset + i)] |= 1 << i;
+  }
+
+  // vp is set to 1^m. Shifting by bitwidth would be undefined behavior
+  let vp = -1;
+  let vn = 0;
+  let currDist = len1;
+
+  let maxMisses = maxDist + len2 - len1;
+  maxMisses = maxMisses < uint32Max ? maxMisses : uint32Max;
+
+  // mask used when computing D[m,j] in the paper 10^(m-1)
+  const mask = 1 << (len1 - 1);
+  for (let j = 0; j < len2; ++j) {
+    // Step 1: Compute d0
+    const x = pmVector[s2.charCodeAt(offset + j)] | vn;
+    const d0 = (((x & vp) + vp) ^ vp) | x;
+
+    // Step 2: Reuse vn and vp to compute HP and HN respectively)
+    vn |= ~(d0 | vp);
+    vp &= d0;
+
+    // Step 3: Compute the value D[m,j] with early exit using maxMisses
+    if (vn & mask) {
+      if (maxMisses < 2) {
+        currDist = maxDist;
+        break;
+      }
+      maxMisses -= 2;
+      ++currDist;
+    } else if (vp & mask) {
+      --currDist;
+    } else {
+      if (maxMisses < 1) {
+        currDist = maxDist;
+        break;
+      }
+      --maxMisses;
+    }
+
+    // Step 4: Compute vp and vn, vn temporarily holds the value of x first
+    vn <<= 1;
+    vn |= 1;
+    vp <<= 1;
+    vp |= ~(d0 | vn);
+    vn &= d0;
+  }
+  // Reset pattern match vector
+  i = len1;
+  while (i--) {
+    pmVector[s1.charCodeAt(offset + i)] = 0;
+  }
+  return currDist;
+};
+
+/**
+ * Implementation of block-based algorithm for Levenshtein distance by Myers
+ * (1999), using computer word size = 32.
+ *
+ * TODO: Fix early exit using maxMisses.
+ *
+ * Reference:
+ * RapidFuzz: https://github.com/maxbachmann/rapidfuzz-cpp
+ * fastest-levenshtein: https://github.com/ka-weihe/fastest-levenshtein
+ *
+ * @param {string} s1 - The first, shorter, string.
+ * @param {string} s2 - The other string.
+ * @param {number} len1 - Length of `s1` less the common suffix.
+ * @param {number} len2 - Length of `s2` less the common suffix.
+ * @param {number} offset - Length of common prefix.
+ * @param {number} maxDist - Maximum edit distance allowed between the `s1`
+ *    and `s2`.
+ * @returns {number} The Levenshtein distance between `s1` and `s2.
+ */
+const myers1999Block = (s1, s2, len1, len2, offset, maxDist) => {
+  const hSize = Math.ceil(len1 / 32);
+  const vSize = Math.ceil(len2 / 32);
+  let currDist = len2;
+  // let maxMisses = maxDist + len2 - len1;
+  // maxMisses = maxMisses < uint32Max ? maxMisses : uint32Max;
+
+  const hpCarrys = [];
+  const hnCarrys = [];
+  for (let h = 0; h < hSize; ++h) {
+    hpCarrys[h] = -1;
+    hnCarrys[h] = 0;
+  }
+  let v = 0;
+  for (; v < vSize - 1; ++v) {
+    let vp = -1;
+    let vn = 0;
+    const start = v * 32;
+    const stop = start + (32 < len2 ? 32 : len2);
+    // Set up pattern match vector
+    let j = stop - start;
+    while (j--) {
+      pmVector[s2.charCodeAt(offset + start + j)] |= 1 << (start + j);
+    }
+    for (let i = 0; i < len1; ++i) {
+      // Step 1: Computing d0
+      const hpCarry = (hpCarrys[(i / 32) | 0] >>> i % 32) & 1;
+      const hnCarry = (hnCarrys[(i / 32) | 0] >>> i % 32) & 1;
+
+      const x = pmVector[s1.charCodeAt(offset + i)] | hnCarry;
+      const d0 = (((x & vp) + vp) ^ vp) | x | vn;
+
+      // Step 2: Reuse vn and vp to compute HP and HN respectively)
+      vn |= ~(d0 | vp);
+      vp &= d0;
+      if ((vn >>> 31) ^ hpCarry) {
+        hpCarrys[(i / 32) | 0] ^= 1 << i % 32;
+      }
+      if ((vp >>> 31) ^ hnCarry) {
+        hnCarrys[(i / 32) | 0] ^= 1 << i % 32;
+      }
+      // Step 4: Computing vp and vn
+      vn <<= 1;
+      vn |= hpCarry;
+      vp <<= 1;
+      vp |= hnCarry;
+      vp |= ~(d0 | vn);
+      vn &= d0;
+    }
+    // Reset pattern match vector
+    j = stop - start;
+    while (j--) {
+      pmVector[s2.charCodeAt(offset + start + j)] = 0;
+    }
+  }
+  let vp = -1;
+  let vn = 0;
+  const start = v * 32;
+  const stop = start + (32 < len2 - start ? 32 : len2 - start);
+  let j = stop - start;
+  while (j--) {
+    pmVector[s2.charCodeAt(offset + start + j)] |= 1 << (start + j);
+  }
+  const last = 1 << (len2 - 1) % 32;
+  for (let i = 0; i < len1; ++i) {
+    // Step 1: Computing d0
+    const hpCarry = (hpCarrys[(i / 32) | 0] >>> i % 32) & 1;
+    const hnCarry = (hnCarrys[(i / 32) | 0] >>> i % 32) & 1;
+
+    const x = pmVector[s1.charCodeAt(offset + i)] | hnCarry;
+    const d0 = (((x & vp) + vp) ^ vp) | x | vn;
+
+    // Step 2: Reuse vn and vp to compute HP and HN respectively)
+    vn |= ~(d0 | vp);
+    vp &= d0;
+
+    // Step 3: Computing the value of D[m,j] with early exit using maxMisses
+    // if (vn & last) {
+    //   if (maxMisses < 2) {
+    //     currDist = maxDist;
+    //     break;
+    //   }
+    //   maxMisses -= 2;
+    //   ++currDist;
+    // } else if (vp & last) {
+    //   --currDist;
+    // } else {
+    //   if (maxMisses < 1) {
+    //     currDist = maxDist;
+    //     break;
+    //   }
+    //   --maxMisses;
+    // }
+    if (vn & last) {
+      ++currDist;
+    } else if (vp & last) {
+      --currDist;
+    }
+
+    // Step 4: Computing vp and vn
+    if ((vn >>> 31) ^ hpCarry) {
+      hpCarrys[(i / 32) | 0] ^= 1 << i % 32;
+    }
+    if ((vp >>> 31) ^ hnCarry) {
+      hnCarrys[(i / 32) | 0] ^= 1 << i % 32;
+    }
+    vn <<= 1;
+    vn |= hpCarry;
+    vp <<= 1;
+    vp |= hnCarry;
+    vp |= ~(d0 | vn);
+    vn &= d0;
+  }
+  j = stop - start;
+  while (j--) {
+    pmVector[s2.charCodeAt(offset + start + j)] = 0;
+  }
+  return currDist < maxDist ? currDist : maxDist;
+};
+
+/**
+ * Implementation of optimized Levenshtein algorithm by SoftWx.Match.
+ *
+ * Reference:
+ * SoftWx.Match: https://github.com/softwx/SoftWx.Match
+ *
+ * @param {string} s1 - The first, shorter, string.
+ * @param {string} s2 - The other string.
+ * @param {number} len1 - Length of `s1` less the common suffix.
+ * @param {number} len2 - Length of `s2` less the common suffix.
+ * @param {number} offset - Length of common prefix.
+ * @param {number} maxDist - Maximum edit distance allowed between the `s1`
+ *    and `s2`.
+ * @returns {number} The Levenshtein distance between `s1` and `s2.
+ */
 const distanceMax = (s1, s2, len1, len2, offset, maxDistance) => {
   for (let i = 0; i < len2; ++i) {
     char1Costs[i] = i < maxDistance ? i + 1 : maxDistance + 1;
@@ -73,16 +341,23 @@ const distanceMax = (s1, s2, len1, len2, offset, maxDistance) => {
   return currentCost <= maxDistance ? currentCost : maxDistance;
 };
 
-const levenjs = (s1, s2, maxDistance) => {
+/**
+ * Returns the Levenshtein distance between two strings.
+ *
+ * @param {string} s1 - The first string.
+ * @param {string} s2 - The other string.
+ * @param {int|undefined} maxDist - Maximum edit distance allowed between the
+ *    `s1` and `s2`. Can be undefined to indicate no threshold.
+ * @returns {number} The Levenshtein distance between `s1` and `s2.
+ */
+const levenjs = (s1, s2, maxDist) => {
   if (s1 === s2) {
     return 0;
   }
 
-  maxDistance = typeof maxDistance === "number" ? maxDistance : Infinity;
+  maxDist = typeof maxDist === "number" ? maxDist : Infinity;
 
-  // If strings of different lengths, ensure shorter string is in s1.
-  // This can result in a little faster speed by spending more time spinning
-  // just the inner loop during the main processing.
+  // Requires s1.length <= s2.length
   if (s1.length > s2.length) {
     [s2, s1] = [s1, s2];
   }
@@ -90,36 +365,42 @@ const levenjs = (s1, s2, maxDistance) => {
   let len1 = s1.length;
   let len2 = s2.length;
 
+  if (len2 - len1 >= maxDist) {
+    return maxDist;
+  }
+
   // Trim suffix
   // Note: `~-` is the bitwise way to perform a `- 1` operation
   while (len1 > 0 && s1.charCodeAt(~-len1) === s2.charCodeAt(~-len2)) {
     --len1;
     --len2;
   }
-
   if (len1 === 0) {
-    return len2 < maxDistance ? len2 : maxDistance;
+    return len2 < maxDist ? len2 : maxDist;
   }
-
   // Trim prefix
   let offset = 0;
   while (offset < len1 && s1.charCodeAt(offset) === s2.charCodeAt(offset)) {
     ++offset;
   }
-
   if (offset !== 0) {
     len1 -= offset;
     len2 -= offset;
   }
   if (len1 === 0) {
-    return len2 < maxDistance ? len2 : maxDistance;
+    return len2;
   }
 
-  if (maxDistance < len2) {
-    return distanceMax(s1, s2, len1, len2, offset, maxDistance);
-  } else {
-    return distance(s1, s2, len1, len2, offset);
+  if (len2 <= 32) {
+    return hyyro2003(s1, s2, len1, len2, offset, maxDist);
   }
+  if (maxDist < 4) {
+    return fujimoto2018(s1, s2, len1, len2, offset, maxDist);
+  }
+
+  return maxDist === Infinity
+    ? myers1999Block(s1, s2, len1, len2, offset, maxDist)
+    : distanceMax(s1, s2, len1, len2, offset, maxDist);
 };
 
 export default levenjs;

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "devDependencies": {
     "benchmark": "^2.1.4",
     "chance": "^1.1.8",
+    "fastest-levenshtein": "^1.0.12",
     "jest": "^27.4.3",
-    "leven": "^4.0.0",
-    "ukkonen": "^1.4.0"
+    "leven": "^4.0.0"
   }
 }

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -9,9 +9,9 @@ const chance = Chance(42);
 
 const numIterations = 100;
 
-const levenshtein = (s1, s2, maxDistance) => {
-  maxDistance = typeof maxDistance === "number" ? maxDistance : Infinity;
-  return Math.min(maxDistance, leven(s1, s2));
+const levenshtein = (s1, s2, maxDist) => {
+  maxDist = typeof maxDist === "number" ? maxDist : Infinity;
+  return Math.min(maxDist, leven(s1, s2));
 };
 
 const edit = () => chance.pickone(["replace", "delete", "insert", "transpose"]);
@@ -67,7 +67,7 @@ const thresholds = () => {
   const count = 20;
   const result = new Array(count);
   for (let i = 0; i < count; ++i) {
-    result[i] = 10 + i;
+    result[i] = i;
   }
   return result;
 };
@@ -106,7 +106,7 @@ describe("levenjs", () => {
     });
   });
 
-  it("produces same result as Ukkonen", () => {
+  it("produces same result as leven", () => {
     strings(numIterations).forEach((s1) => {
       strings(numIterations).forEach((s2) => {
         expect(levenjs(s1, s2)).toBe(leven(s1, s2));


### PR DESCRIPTION
- Add Fujimoto (2018) `mbleven` algorithm for `maxDist<4`
  - Used when trimmed string length > 32 since Hyyro is still faster when length <= 32
- Add Hyyro (2003) algorithm for longest trimmed string length <= 32
- Add Myers (1999) block-based algorithm for longer strings
  - Early exit doesn't work, only called when uncapped.
- Add benchmark cases to demonstrate when `levenjs` can be faster than `fastest-levenshtein`